### PR TITLE
Correct package names for Red Hat distributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,15 @@ Wget-lua is also available on [ArchiveTeam's PPA](https://launchpad.net/~archive
 
 Ensure that you have the CentOS equivalent of bzip2 installed as well. You will the EPEL repository to be enabled.
 
-    yum -y install autoconf automake flex gnutls-devel lua-devel python-pip zlib-devel
+    yum -y groupinstall "Development Tools"
+    yum -y install gnutls-devel lua-devel python-pip zlib-devel zstd libzstd-devel git-core gperf lua-socket luarocks texinfo git rsync gettext-devel
+    pip install --upgrade seesaw
+    [... pretty much the same as above ...]
+
+### For Fedora:
+
+    dnf -y groupinstall "Development Tools"
+    dnf -y install gnutls-devel lua-devel python-pip zlib-devel zstd libzstd-devel git-core gperf lua-socket luarocks texinfo git rsync gettext-devel
     pip install --upgrade seesaw
     [... pretty much the same as above ...]
 


### PR DESCRIPTION
No `python-devel` was needed.
Lua, zlib1g and gnutls packages don't have the same names as in Debian.
The following packages were available at the time of compilation:

lua-devel-5.1.4-15.el7.x86_64
lua-5.1.4-15.el7.x86_64
gnutls-devel-3.3.29-9.el7_6.x86_64
zlib-devel-1.2.7-18.el7.x86_64