### PR TITLE
Accept all 1.4.x zstd versions

### DIFF
--- a/get-wget-lua.sh
+++ b/get-wget-lua.sh
@@ -18,7 +18,7 @@ then
   fi
 fi
 
-if ! zstd --version | grep -q 1.4.4
+if ! zstd --version | grep -q 1.4
 then
   echo "Need version 1.4.4 of libzstd-dev and zstd"
   exit 1


### PR DESCRIPTION
wget.lua compiles with 1.4.5-3 as well.
Fedora 31+ and EL7 repos ship 1.4.5+.